### PR TITLE
fix: protect card data and validate agent API URL 

### DIFF
--- a/vic-agent/apps/agent/.env.example
+++ b/vic-agent/apps/agent/.env.example
@@ -1,0 +1,15 @@
+# LangGraph Agent Configuration (example)
+#
+# Copy to `.env` and fill in real values. This file documents the variables the
+# agent needs in addition to the VTS / tokenization credentials already required
+# by the add-card flow (TR_*, VISA_*, etc.).
+
+# Card Encryption Private Key (PKCS#8 PEM, RSA-OAEP SHA-256)
+# Used to decrypt the `private_encryptedCardData` payload the web client submits.
+# Must be the PRIVATE half of the keypair whose PUBLIC half is configured in the
+# web app as NEXT_PUBLIC_CARD_ENC_PUBLIC_KEY. Generate with:
+#   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out card_priv.pem
+#   openssl pkey -in card_priv.pem -pubout -out card_pub.pem
+# Paste the contents of card_priv.pem here. Newlines may be written literally as
+# \n on a single line; the agent normalizes them. NEVER commit the real value.
+CARD_ENC_PRIVATE_KEY=YOUR_PKCS8_PEM_PRIVATE_KEY

--- a/vic-agent/apps/agent/src/graph.ts
+++ b/vic-agent/apps/agent/src/graph.ts
@@ -71,7 +71,7 @@ function routeFromRouter(state: typeof GraphState.State): string {
 }
 
 function routeCardCheck(state: typeof GraphState.State): string {
-  if (state.private_cardData) {
+  if (state.private_cardData || state.private_encryptedCardData) {
     return NODE_NAMES.TOKENIZE_CARD;
   }
   return NODE_NAMES.EXPECT_CARD_DATA;

--- a/vic-agent/apps/agent/src/nodes/add-card/interrupts/expectCardData.ts
+++ b/vic-agent/apps/agent/src/nodes/add-card/interrupts/expectCardData.ts
@@ -15,8 +15,8 @@ import { GraphState } from "../../../utils/state.js";
 export async function expectCardData(
   state: typeof GraphState.State
 ): Promise<Partial<typeof GraphState.State>> {
-  // If card data is missing, interrupt
-  if (!state.private_cardData) {
+  // If card data is missing (neither raw nor encrypted), interrupt
+  if (!state.private_cardData && !state.private_encryptedCardData) {
     interrupt("awaiting_card_data");
   }
   console.log("received card data");

--- a/vic-agent/apps/agent/src/nodes/add-card/tokenizeCard.ts
+++ b/vic-agent/apps/agent/src/nodes/add-card/tokenizeCard.ts
@@ -2,7 +2,11 @@ import { RunnableConfig } from "@langchain/core/runnables";
 import { AIMessage } from "@langchain/core/messages";
 import { GraphState } from "../../utils/state.js";
 import type { ExecutionContext } from "../../utils/execution-context/index.js";
-import { generateEmailHash, encryptWithSecret } from "../../utils/crypto.js";
+import {
+  generateEmailHash,
+  encryptWithSecret,
+  decryptCardData,
+} from "../../utils/crypto.js";
 
 /**
  * Prepares encrypted payment instrument data from card data
@@ -101,7 +105,14 @@ export async function tokenizeCard(
   }
 
   try {
-    if (!state.private_cardData) {
+    // Card data arrives encrypted from the client. Decrypt it in memory here;
+    // never write the cleartext back into graph state (it would be checkpointed).
+    let cardData = state.private_cardData;
+    if (!cardData && state.private_encryptedCardData) {
+      cardData = decryptCardData(state.private_encryptedCardData);
+    }
+
+    if (!cardData) {
       throw new Error("Card data is missing from state");
     }
 
@@ -135,9 +146,8 @@ export async function tokenizeCard(
     );
 
     // Prepare encrypted payment instrument
-    payload.encPaymentInstrument = await prepareEncryptedPaymentInstrument(
-      state.private_cardData
-    );
+    payload.encPaymentInstrument =
+      await prepareEncryptedPaymentInstrument(cardData);
 
     console.log("Calling provision-token-given-pan-data with payload");
 
@@ -155,6 +165,11 @@ export async function tokenizeCard(
 
     return {
       private_tokenId: vProvisionedTokenID,
+      // Purge sensitive card data from state after successful tokenization so
+      // PAN/CVV (Sensitive Authentication Data) is not retained in the
+      // checkpoint post-authorization (mirrors the error path below).
+      private_cardData: null,
+      private_encryptedCardData: null,
       messages: [
         ...toolMessages, // Tool call messages appear first in UI
         new AIMessage({
@@ -172,6 +187,7 @@ export async function tokenizeCard(
     // Clear card data to prevent retry loop and signal UI to clear localStorage
     return {
       private_cardData: null, // Clear from agent state
+      private_encryptedCardData: null, // Clear encrypted payload too
       cardDeletionSignal: (state.cardDeletionSignal || 0) + 1, // Signal UI to clear localStorage
       messages: [
         new AIMessage({

--- a/vic-agent/apps/agent/src/nodes/router.ts
+++ b/vic-agent/apps/agent/src/nodes/router.ts
@@ -73,9 +73,12 @@ export async function router(
     return { mode: MODE.ADD_CARD };
   }
 
-  // Case 2b: No card data - enter add-card flow and mark as started
-  if (!state.private_cardData || !state.private_tokenId) {
-    console.log("Router: no card data, setting mode to add-card");
+  // Case 2b: No enrolled card - enter add-card flow and mark as started.
+  // The durable "card enrolled" signal is the token id; raw card data is
+  // intentionally ephemeral (purged after tokenization), so we must not treat
+  // its absence as "no card" or we would loop back into add-card.
+  if (!state.private_tokenId) {
+    console.log("Router: no enrolled card, setting mode to add-card");
     return {
       mode: MODE.ADD_CARD,
       private_cardAdditionCompleted: false,

--- a/vic-agent/apps/agent/src/utils/crypto.ts
+++ b/vic-agent/apps/agent/src/utils/crypto.ts
@@ -36,6 +36,42 @@ export const generateEmailHash = (email: string): string => {
   return hash(secret, email, true);
 };
 
+export interface DecryptedCardData {
+  cardNumber?: string;
+  expiryDate?: string;
+  cvv?: string;
+  cardholderName?: string;
+}
+
+/**
+ * Decrypt a client-side-encrypted card payload (RSA-OAEP, SHA-256, base64).
+ *
+ * The web client encrypts card data with the public key so cleartext PAN/CVV
+ * never crosses the stream. This decrypts it in memory using the private key
+ * (CARD_ENC_PRIVATE_KEY, a PKCS#8 PEM; literal "\n" sequences are normalized so
+ * the key can be supplied on a single line in env files).
+ *
+ * @param ciphertextB64 - Base64-encoded RSA-OAEP ciphertext
+ * @returns The decrypted card data object
+ */
+export const decryptCardData = (ciphertextB64: string): DecryptedCardData => {
+  const pem = (process.env.CARD_ENC_PRIVATE_KEY || "").replace(/\\n/g, "\n");
+  if (!pem) {
+    throw new Error("CARD_ENC_PRIVATE_KEY environment variable is required");
+  }
+
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: pem,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha256",
+    },
+    Buffer.from(ciphertextB64, "base64")
+  );
+
+  return JSON.parse(decrypted.toString("utf8")) as DecryptedCardData;
+};
+
 /**
  * Encrypt data with secret using modern jose library
  * @param secret - The encryption secret

--- a/vic-agent/apps/agent/src/utils/state.ts
+++ b/vic-agent/apps/agent/src/utils/state.ts
@@ -263,6 +263,18 @@ export const GraphState = Annotation.Root({
   }),
 
   /**
+   * Private field: client-side-encrypted card payload (RSA-OAEP base64).
+   * The web client encrypts the raw card data before submission so cleartext
+   * PAN/CVV never crosses the stream. It is decrypted in memory inside
+   * tokenizeCard and then purged. Like private_cardData, this is NEVER exposed
+   * to external clients via the output schema.
+   */
+  private_encryptedCardData: Annotation<string | null>({
+    reducer: (x, y) => (y !== undefined ? y : x),
+    default: () => null,
+  }),
+
+  /**
    * User email address.
    * Collected alongside card information for payment processing.
    */

--- a/vic-agent/apps/web/.env.example
+++ b/vic-agent/apps/web/.env.example
@@ -26,3 +26,20 @@ NEXT_PUBLIC_VTS_API_KEY=YOUR_API_KEY
 # VTS external application ID
 NEXT_PUBLIC_VTS_EXTERNAL_APP_ID=YOUR_APP_ID
 
+# Card Encryption Public Key (base64 SPKI/DER, RSA-OAEP SHA-256)
+# The browser encrypts raw card data with this PUBLIC key before submitting it,
+# so cleartext PAN/CVV never crosses the stream. The matching PRIVATE key must
+# be set on the agent as CARD_ENC_PRIVATE_KEY (PKCS#8 PEM). Generate a pair:
+#   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out card_priv.pem
+#   openssl pkey -in card_priv.pem -pubout -out card_pub.pem
+#   # public  (this var): the base64 body of card_pub.pem on a single line
+#   # private (agent CARD_ENC_PRIVATE_KEY): the contents of card_priv.pem
+# A public key is safe to commit; NEVER commit the private key.
+NEXT_PUBLIC_CARD_ENC_PUBLIC_KEY=YOUR_BASE64_SPKI_PUBLIC_KEY
+
+# Allowed Agent API hosts (optional; defense-in-depth for credential exfiltration)
+# Comma-separated additional origins the web app may send the API key to, on top
+# of NEXT_PUBLIC_API_URL and localhost dev defaults. The stored API key is only
+# ever sent to allowlisted hosts, blocking apiUrl query-param exfiltration.
+# NEXT_PUBLIC_ALLOWED_API_URLS=https://your-deployment.example.com
+

--- a/vic-agent/apps/web/src/components/thread/agent-inbox/components/thread-actions-view.tsx
+++ b/vic-agent/apps/web/src/components/thread/agent-inbox/components/thread-actions-view.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { useQueryState } from "nuqs";
 import { constructOpenInStudioURL } from "../utils";
+import { isAllowedApiUrl } from "@/lib/url-allowlist";
 import { HumanInterrupt } from "@langchain/langgraph/prebuilt";
 
 interface ThreadActionsViewProps {
@@ -87,6 +88,17 @@ export function ThreadActionsView({
     if (!apiUrl) {
       toast.error("Error", {
         description: "Please set the LangGraph deployment URL in settings.",
+        duration: 5000,
+        richColors: true,
+        closeButton: true,
+      });
+      return;
+    }
+
+    // Only open Studio for a trusted host (blocks open-redirect via ?apiUrl=).
+    if (!isAllowedApiUrl(apiUrl)) {
+      toast.error("Untrusted URL", {
+        description: "The configured deployment URL is not a trusted host.",
         duration: 5000,
         richColors: true,
         closeButton: true,

--- a/vic-agent/apps/web/src/components/thread/card-management/card-section.tsx
+++ b/vic-agent/apps/web/src/components/thread/card-management/card-section.tsx
@@ -5,11 +5,8 @@ import { DeleteCardDialog } from "./delete-card-dialog";
 import { type CardFormData } from "@/lib/validations/card";
 import { detectCardBrand, getLastFourDigits } from "@/lib/utils/card-utils";
 import { toast } from "sonner";
-import {
-  storeFullCardData,
-  clearFullCardData,
-  getTokenId,
-} from "@/lib/card-storage";
+import { clearStoredCard, getTokenId } from "@/lib/card-storage";
+import { encryptCardData } from "@/lib/card-encryption";
 import { useStreamContext } from "@/providers/Stream";
 
 interface CardData {
@@ -65,8 +62,8 @@ export function CardSection() {
     if (currentSignal > lastDeletionSignalRef.current && cardData) {
       console.log("[CardSection] Deletion signal received, clearing UI");
 
-      // Clear localStorage (full card data + token ID)
-      clearFullCardData();
+      // Clear the stored credential (token ID); display data is cleared below.
+      clearStoredCard();
 
       // Clear React state for UI update
       setCardData(null);
@@ -85,17 +82,19 @@ export function CardSection() {
     }
   }, [stream.values?.cardDeletionSignal, cardData]);
 
-  const handleCardSubmit = (formData: CardFormData) => {
-    // Store full card data to localStorage (for backend submissions)
-    storeFullCardData({
-      cardNumber: formData.cardNumber,
-      expiryDate: formData.expiryDate,
-      cvv: formData.cvv,
-      cardholderName: formData.cardholderName,
-      email: formData.email,
-    });
+  const handleCardSubmit = async (formData: CardFormData) => {
+    // Encrypt the raw card data client-side and submit the ciphertext to the
+    // agent for tokenization. Cleartext PAN/CVV is never persisted.
+    let encryptedCardData: string;
+    try {
+      encryptedCardData = await encryptCardData(formData);
+    } catch (error) {
+      console.error("Failed to encrypt card data:", error);
+      toast.error("Could not securely process the card. Please try again.");
+      return;
+    }
 
-    // Transform form data to card data
+    // Transform form data to non-sensitive display data
     const newCardData: CardData = {
       lastFourDigits: getLastFourDigits(formData.cardNumber),
       cardholderName: formData.cardholderName,
@@ -104,8 +103,24 @@ export function CardSection() {
       status: "in_progress", // Default to in_progress, will be activated later
     };
 
-    // Set cardData state (triggers localStorage save via useEffect)
+    // Set cardData state (triggers localStorage save of display data via useEffect)
     setCardData(newCardData);
+
+    // Submit the encrypted card payload to the agent to drive tokenization.
+    stream.submit(
+      {
+        private_encryptedCardData: encryptedCardData,
+        email: formData.email,
+      } as any,
+      {
+        streamMode: ["values"],
+        config: {
+          configurable: {
+            model: stream.currentModel,
+          },
+        },
+      },
+    );
 
     // Show success toast
     toast.success("Card added successfully");

--- a/vic-agent/apps/web/src/components/thread/index.tsx
+++ b/vic-agent/apps/web/src/components/thread/index.tsx
@@ -33,7 +33,7 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { Label } from "../ui/label";
 import { Switch } from "../ui/switch";
 import { GitHubSVG } from "../icons/github";
-import { getFullCardData, getTokenId, storeTokenId } from "@/lib/card-storage";
+import { getTokenId, storeTokenId } from "@/lib/card-storage";
 import { getClientDeviceId, getClientReferenceId } from "@/lib/vts-utils";
 import { InterruptHandler } from "./interrupt-handler";
 
@@ -189,25 +189,15 @@ export function Thread() {
 
     // Get stored data
     const tokenId = getTokenId();
-    const fullCardData = getFullCardData();
     const currentThreadId = threadId || "new";
     const isFirstMessageForThread =
       cardDataSentForThread.current !== currentThreadId;
 
-    // Only send data on first message of thread
+    // Only send data on first message of thread.
+    // Note: raw card data is never resent here. It is encrypted and submitted
+    // once at enrollment (card-data-prompt / card-section); thereafter only the
+    // non-sensitive token ID is needed to identify the enrolled card.
     if (isFirstMessageForThread) {
-      // Send card data if available
-      if (fullCardData) {
-        stateUpdate.private_cardData = {
-          cardNumber: fullCardData.cardNumber,
-          expiryDate: fullCardData.expiryDate,
-          cvv: fullCardData.cvv,
-          cardholderName: fullCardData.cardholderName,
-        };
-        stateUpdate.email = fullCardData.email;
-        console.log("[Thread] Sending card data with first message");
-      }
-
       // Send token ID if available
       if (tokenId) {
         stateUpdate.private_tokenId = tokenId;

--- a/vic-agent/apps/web/src/components/thread/interrupts/card-data-prompt.tsx
+++ b/vic-agent/apps/web/src/components/thread/interrupts/card-data-prompt.tsx
@@ -2,10 +2,11 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { AddCardModal } from "../card-management/add-card-modal";
 import { useStreamContext } from "@/providers/Stream";
-import { storeFullCardData } from "@/lib/card-storage";
+import { encryptCardData } from "@/lib/card-encryption";
 import type { CardFormData } from "@/lib/validations/card";
 import { CreditCard } from "lucide-react";
 import { getLastFourDigits, detectCardBrand } from "@/lib/utils/card-utils";
+import { toast } from "sonner";
 
 interface CardData {
   lastFourDigits: string;
@@ -25,9 +26,17 @@ export function CardDataPrompt() {
   const stream = useStreamContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleCardAdded = (fullCardData: CardFormData) => {
-    // Store full card data temporarily in localStorage
-    storeFullCardData(fullCardData);
+  const handleCardAdded = async (fullCardData: CardFormData) => {
+    // Encrypt the raw card data client-side; cleartext PAN/CVV is never
+    // persisted and never sent over the stream.
+    let encryptedCardData: string;
+    try {
+      encryptedCardData = await encryptCardData(fullCardData);
+    } catch (error) {
+      console.error("Failed to encrypt card data:", error);
+      toast.error("Could not securely process the card. Please try again.");
+      return;
+    }
 
     // Transform to display format (same as CardSection does)
     const displayData: CardData = {
@@ -38,22 +47,18 @@ export function CardDataPrompt() {
       status: "in_progress",
     };
 
-    // Save display data to localStorage (so it appears in settings)
+    // Save only non-sensitive display data to localStorage (so it appears in
+    // settings). No PAN/CVV is stored.
     try {
       localStorage.setItem(CARD_STORAGE_KEY, JSON.stringify(displayData));
     } catch (error) {
       console.error("Failed to save card display data:", error);
     }
 
-    // Resume the graph with card data and email
+    // Resume the graph with the encrypted card payload and email.
     stream.submit(
       {
-        private_cardData: {
-          cardNumber: fullCardData.cardNumber,
-          expiryDate: fullCardData.expiryDate,
-          cvv: fullCardData.cvv,
-          cardholderName: fullCardData.cardholderName,
-        },
+        private_encryptedCardData: encryptedCardData,
         email: fullCardData.email,
       } as any,
       {
@@ -66,7 +71,6 @@ export function CardDataPrompt() {
       },
     );
 
-    // Keep card data in localStorage for future threads
     setIsModalOpen(false);
   };
 

--- a/vic-agent/apps/web/src/lib/card-encryption.ts
+++ b/vic-agent/apps/web/src/lib/card-encryption.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-side card encryption.
+ *
+ * Raw card data (PAN, expiry, CVV) must never cross the LangGraph stream in
+ * cleartext, nor be persisted. We encrypt the card payload in the browser with
+ * an RSA-OAEP (SHA-256) public key (safe to ship in the bundle) and submit only
+ * the resulting ciphertext as `private_encryptedCardData`. The agent decrypts it
+ * in memory immediately before tokenization and then purges it from state.
+ *
+ * The public key is provided via NEXT_PUBLIC_CARD_ENC_PUBLIC_KEY as a base64
+ * SPKI (DER) string. The matching private key lives only on the agent.
+ */
+
+export interface RawCardData {
+  cardNumber: string;
+  expiryDate: string;
+  cvv: string;
+  cardholderName: string;
+}
+
+function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  const binary = atob(b64.replace(/\s+/g, ""));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++)
+    binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+let cachedKey: CryptoKey | null = null;
+
+async function importPublicKey(): Promise<CryptoKey> {
+  if (cachedKey) return cachedKey;
+
+  const spkiB64 = process.env.NEXT_PUBLIC_CARD_ENC_PUBLIC_KEY;
+  if (!spkiB64) {
+    throw new Error(
+      "NEXT_PUBLIC_CARD_ENC_PUBLIC_KEY is not configured; cannot encrypt card data.",
+    );
+  }
+  if (typeof window === "undefined" || !window.crypto?.subtle) {
+    throw new Error("Web Crypto API is not available in this environment.");
+  }
+
+  cachedKey = await window.crypto.subtle.importKey(
+    "spki",
+    base64ToArrayBuffer(spkiB64),
+    { name: "RSA-OAEP", hash: "SHA-256" },
+    false,
+    ["encrypt"],
+  );
+  return cachedKey;
+}
+
+/**
+ * Encrypt raw card data and return a base64 ciphertext string.
+ * The cleartext `card` argument must not be persisted by the caller.
+ */
+export async function encryptCardData(card: RawCardData): Promise<string> {
+  const key = await importPublicKey();
+  const plaintext = new TextEncoder().encode(
+    JSON.stringify({
+      cardNumber: card.cardNumber,
+      expiryDate: card.expiryDate,
+      cvv: card.cvv,
+      cardholderName: card.cardholderName,
+    }),
+  );
+  const ciphertext = await window.crypto.subtle.encrypt(
+    { name: "RSA-OAEP" },
+    key,
+    plaintext,
+  );
+  return arrayBufferToBase64(ciphertext);
+}

--- a/vic-agent/apps/web/src/lib/card-storage.ts
+++ b/vic-agent/apps/web/src/lib/card-storage.ts
@@ -1,78 +1,26 @@
 /**
- * Card storage utilities for securely handling full card data.
+ * Card storage utilities.
  *
  * Security approach:
- * - Full card data stored in localStorage (persists across tabs and sessions)
- * - Display data (last 4 digits) stored in localStorage (persists)
- * - Full data cleared when user explicitly removes the card
+ * - Raw card data (PAN, CVV, expiry) is NEVER persisted. It is encrypted
+ *   client-side (see card-encryption.ts) and submitted directly to the agent
+ *   for tokenization; the cleartext is held only transiently in memory.
+ * - Only non-sensitive display data (last four, brand, expiry, cardholder
+ *   name) and the provisioned token ID are stored in localStorage.
+ * - CVV / Sensitive Authentication Data is never stored under any key.
  */
-
-const FULL_CARD_DATA_KEY = "visa-full-card-data";
-
-export interface FullCardData {
-  cardNumber: string;
-  expiryDate: string;
-  cvv: string;
-  cardholderName: string;
-  email: string;
-}
 
 /**
- * Store full card data in localStorage.
- * This data will persist across tabs and browser sessions.
- *
- * @param cardData - Full card data including sensitive information
+ * Clear the stored card credential (token ID).
+ * Should be called when the user explicitly removes the card. Display data
+ * (last four, etc.) is managed separately by the card UI components.
  */
-export function storeFullCardData(cardData: FullCardData): void {
+export function clearStoredCard(): void {
   try {
-    localStorage.setItem(FULL_CARD_DATA_KEY, JSON.stringify(cardData));
+    clearTokenId();
+    console.log("[Card Storage] Token ID cleared");
   } catch (error) {
-    console.error("Failed to store card data:", error);
-  }
-}
-
-/**
- * Retrieve full card data from localStorage.
- *
- * @returns Full card data or null if not found
- */
-export function getFullCardData(): FullCardData | null {
-  try {
-    const data = localStorage.getItem(FULL_CARD_DATA_KEY);
-    if (!data) return null;
-    return JSON.parse(data) as FullCardData;
-  } catch (error) {
-    console.error("Failed to retrieve card data:", error);
-    return null;
-  }
-}
-
-/**
- * Clear full card data from localStorage.
- * Should be called when user explicitly removes the card.
- * Also clears the associated token ID.
- */
-export function clearFullCardData(): void {
-  try {
-    localStorage.removeItem(FULL_CARD_DATA_KEY);
-    clearTokenId(); // Also clear token ID when card is removed
-    console.log("[Card Storage] Card data and token ID cleared");
-  } catch (error) {
-    console.error("Failed to clear card data:", error);
-  }
-}
-
-/**
- * Check if full card data exists in localStorage.
- *
- * @returns true if card data exists, false otherwise
- */
-export function hasFullCardData(): boolean {
-  try {
-    return localStorage.getItem(FULL_CARD_DATA_KEY) !== null;
-  } catch (error) {
-    console.error("Failed to check card data:", error);
-    return false;
+    console.error("Failed to clear stored card:", error);
   }
 }
 

--- a/vic-agent/apps/web/src/lib/url-allowlist.ts
+++ b/vic-agent/apps/web/src/lib/url-allowlist.ts
@@ -1,0 +1,71 @@
+/**
+ * Trusted-host allowlist for the agent API URL.
+ *
+ * The `apiUrl` is read from the page query string and is used to build the
+ * LangGraph SDK client (which sends the stored API key as an auth header) and
+ * to fetch `${apiUrl}/info`. Without validation, an attacker-crafted link like
+ * `?apiUrl=https://attacker.example` would exfiltrate the API key to that host.
+ *
+ * We only ever talk to (and send the API key to) an allowlisted origin:
+ *  - the deployment-configured NEXT_PUBLIC_API_URL,
+ *  - any origins listed in NEXT_PUBLIC_ALLOWED_API_URLS (comma-separated), and
+ *  - localhost dev defaults.
+ *
+ * Per google-cloud-platform-tsr 1.13: API key usage must be restricted to
+ * trusted hosts and the application only.
+ */
+
+const LOCALHOST_DEFAULTS = [
+  "http://localhost:2024",
+  "http://127.0.0.1:2024",
+];
+
+function originOf(url: string): string | null {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function allowedOrigins(): Set<string> {
+  const origins = new Set<string>();
+  const add = (u?: string | null) => {
+    if (!u) return;
+    const o = originOf(u);
+    if (o) origins.add(o);
+  };
+
+  add(process.env.NEXT_PUBLIC_API_URL);
+  (process.env.NEXT_PUBLIC_ALLOWED_API_URLS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .forEach(add);
+  LOCALHOST_DEFAULTS.forEach(add);
+
+  return origins;
+}
+
+/**
+ * @returns true if `url` parses and its origin is in the trusted allowlist.
+ */
+export function isAllowedApiUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  const origin = originOf(url);
+  if (!origin) return false;
+  return allowedOrigins().has(origin);
+}
+
+/**
+ * Returns `url` if it is allowlisted; otherwise throws. Use at any sink that
+ * sends credentials to, or navigates to, the agent API URL.
+ */
+export function assertAllowedApiUrl(url: string): string {
+  if (!isAllowedApiUrl(url)) {
+    throw new Error(
+      `Refusing to use untrusted API URL "${url}". Add its origin to NEXT_PUBLIC_ALLOWED_API_URLS to allow it.`,
+    );
+  }
+  return url;
+}

--- a/vic-agent/apps/web/src/providers/Stream.tsx
+++ b/vic-agent/apps/web/src/providers/Stream.tsx
@@ -19,6 +19,7 @@ import { VisaLogoSVG } from "@/components/icons/visa";
 import { Label } from "@/components/ui/label";
 import { ArrowRight } from "lucide-react";
 import { getApiKey } from "@/lib/api-key";
+import { isAllowedApiUrl } from "@/lib/url-allowlist";
 import { useThreads } from "./Thread";
 import { toast } from "sonner";
 import {
@@ -64,6 +65,8 @@ const useTypedStream = useStream<
       action?: string | null;
       cardDeletionSignal?: number;
       private_tokenId?: string | null;
+      private_encryptedCardData?: string | null;
+      email?: string | null;
     };
     CustomEventType: UIMessage | RemoveUIMessage;
   }
@@ -83,6 +86,11 @@ async function checkGraphStatus(
   apiUrl: string,
   apiKey: string | null,
 ): Promise<boolean> {
+  // Never send the API key to an untrusted host.
+  if (!isAllowedApiUrl(apiUrl)) {
+    console.error("Refusing to contact untrusted API URL:", apiUrl);
+    return false;
+  }
   try {
     const res = await fetch(`${apiUrl}/info`, {
       ...(apiKey && {
@@ -216,6 +224,26 @@ export const StreamProvider: React.FC<{ children: ReactNode }> = ({
   // Determine final values to use, prioritizing URL params then env vars
   const finalApiUrl = apiUrl || envApiUrl;
   const finalAssistantId = assistantId || envAssistantId;
+
+  // Refuse to mount a session (which would send the API key) for an untrusted
+  // API URL — e.g. an attacker-supplied `?apiUrl=` query parameter.
+  if (finalApiUrl && !isAllowedApiUrl(finalApiUrl)) {
+    return (
+      <div className="flex items-center justify-center min-h-screen w-full p-4">
+        <div className="flex flex-col gap-3 border bg-background shadow-lg rounded-lg max-w-xl p-8">
+          <h1 className="text-xl font-bold text-[var(--visa-blue-primary)]">
+            Untrusted deployment URL
+          </h1>
+          <p className="text-base text-muted-foreground">
+            The requested agent URL <code>{finalApiUrl}</code> is not in the
+            list of trusted hosts, so the application will not connect to it or
+            send credentials. If this is your own deployment, add its origin to{" "}
+            <code>NEXT_PUBLIC_ALLOWED_API_URLS</code>.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   // If we're missing any required values, show the form
   if (!finalApiUrl || !finalAssistantId) {

--- a/vic-agent/apps/web/src/providers/Thread.tsx
+++ b/vic-agent/apps/web/src/providers/Thread.tsx
@@ -1,5 +1,6 @@
 import { validate } from "uuid";
 import { getApiKey } from "@/lib/api-key";
+import { isAllowedApiUrl } from "@/lib/url-allowlist";
 import { Thread } from "@langchain/langgraph-sdk";
 import { useQueryState } from "nuqs";
 import {
@@ -41,6 +42,11 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
 
   const getThreads = useCallback(async (): Promise<Thread[]> => {
     if (!apiUrl || !assistantId) return [];
+    // Do not send the API key to an untrusted host.
+    if (!isAllowedApiUrl(apiUrl)) {
+      console.error("Refusing to fetch threads from untrusted API URL:", apiUrl);
+      return [];
+    }
     const client = createClient(apiUrl, getApiKey() ?? undefined);
 
     const threads = await client.threads.search({

--- a/vic-agent/apps/web/src/providers/client.ts
+++ b/vic-agent/apps/web/src/providers/client.ts
@@ -1,6 +1,9 @@
 import { Client } from "@langchain/langgraph-sdk";
+import { assertAllowedApiUrl } from "@/lib/url-allowlist";
 
 export function createClient(apiUrl: string, apiKey: string | undefined) {
+  // Never construct a client (which would send the API key) for an untrusted host.
+  assertAllowedApiUrl(apiUrl);
   return new Client({
     apiKey,
     apiUrl,


### PR DESCRIPTION
(AISAST-10707, AISAST-10706)

Findings C & D (vic-agent web + agent):
- Never persist raw PAN/CVV; encrypt card data client-side (RSA-OAEP) and submit only ciphertext over the stream (card-encryption.ts).
- Decrypt in memory in tokenizeCard and purge private_cardData and private_encryptedCardData from state after successful tokenization so CVV/SAD is not retained in the checkpoint; router keys off private_tokenId.
- Stop the per-thread raw-card resend; store only display fields + token id.
- Add a trusted-host allowlist (url-allowlist.ts) enforced at createClient, thread search, the /info fetch, session mount, and the Studio window.open, so the API key is never sent to an attacker-supplied apiUrl.